### PR TITLE
Display signup notes on raid page

### DIFF
--- a/app/components/raid-signup.js
+++ b/app/components/raid-signup.js
@@ -6,8 +6,14 @@ export default Ember.Component.extend({
   rolesSorting: ['slug:desc'],
   sortedRoles: Ember.computed.sort('signup.roles', 'rolesSorting'),
 
+  attributeBindings: ['note:title'],
+
+  note: function() {
+    return this.get('signup.note');
+  }.property('signup.note'),
+
   classes: function() {
-    var classes = 'class-' + this.get('signup.character.class_id');
+    var classes = 'class class-' + this.get('signup.character.class_id');
     if(this.get('preferred')) {
       classes += ' preferred';
     }

--- a/app/styles/main.less
+++ b/app/styles/main.less
@@ -242,6 +242,14 @@ header {
           padding: 5px 10px;
           margin-bottom: 5px;
           background-color: @gray-darker;
+
+          &[title]:not([title=""]) {
+            cursor: help;
+
+            .class {
+              border-bottom: 1px dotted gray;
+            }
+          }
         }
       }
     }

--- a/app/templates/raid.hbs
+++ b/app/templates/raid.hbs
@@ -59,7 +59,7 @@
           <div class="signup-wrapper">
             <h3><i {{bind-attr class="seatedRole.role.iconClasses"}}></i> <small>{{seatedRole.role.name}}</small></h3>
             {{#each signup in seatedRole.signups itemController="signup"}}
-            {{raid-signup signup=signup account=account seat="seat" unseat="unseat" unsignup="unsignup"}}
+              {{raid-signup signup=signup account=account seat="seat" unseat="unseat" unsignup="unsignup"}}
             {{/each}}
           </div>
         {{/each}}


### PR DESCRIPTION
When signing up the user is able to enter a note for their character. Notes now appear in a tooltip when hovering over a user's signup. Users with notes are specially styled.
